### PR TITLE
ASM-4753  Reconfigure HA

### DIFF
--- a/lib/puppet/type/transport.rb
+++ b/lib/puppet/type/transport.rb
@@ -6,6 +6,10 @@ Puppet::Type.newtype(:transport) do
     desc "The name of the network transport."
   end
 
+  newparam(:endpoint) do
+
+  end
+
   newparam(:username) do
   end
 


### PR DESCRIPTION
Added the endpoint param to override the name for the device_config
parse.  We can't re-use two puppet resources with the same name so this
is an extra param for when we have to define a vcenter transport more
than once. For example, in the firmware update manifest